### PR TITLE
Drop the database before creating

### DIFF
--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -150,6 +150,11 @@ install_db() {
 		fi
 	fi
 
+	# Drop the database before creating it.
+	set +e
+	mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	set -e
+
 	# create database
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }


### PR DESCRIPTION
There is a leaky test on Mantle that causes tests to fail randomly (https://github.com/alleyinteractive/mantle-framework/issues/224). As a solution, we're automatically retrying the unit tests after they fail to just try again. However, the `install-wp-tests.sh` script does not allow for that because it always runs `mysqladmin create $DB_NAME`. This change drops the database between runs to allow for consecutive unit test runs using the `bin/install-wp-tests.sh` script.