### PR TITLE
Throw an error in CI if the file download failed

### DIFF
--- a/.github/workflows/test-script.yml
+++ b/.github/workflows/test-script.yml
@@ -31,11 +31,8 @@ jobs:
       - name: "Run install-wp-tests.sh"
         shell: bash
         run: |
-          set -o xtrace
           rm -rf $WP_CORE_DIR
           bash install-wp-tests.sh wordpress_unit_tests "$WP_DB_USER" "$WP_DB_PASSWORD" "$WP_DB_HOST" $WP_VERSION true
       - name: "Check Installation"
         shell: bash
-        run: |
-          set -o xtrace
-          bash bin/test-script.sh
+        run: bash bin/test-script.sh

--- a/.github/workflows/test-script.yml
+++ b/.github/workflows/test-script.yml
@@ -31,8 +31,11 @@ jobs:
       - name: "Run install-wp-tests.sh"
         shell: bash
         run: |
+          set -o xtrace
           rm -rf $WP_CORE_DIR
           bash install-wp-tests.sh wordpress_unit_tests "$WP_DB_USER" "$WP_DB_PASSWORD" "$WP_DB_HOST" $WP_VERSION true
       - name: "Check Installation"
         shell: bash
-        run: bash bin/test-script.sh
+        run: |
+          set -o xtrace
+          bash bin/test-script.sh

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -30,9 +30,15 @@ download() {
 	fi
 
 	if [ $(which curl) ]; then
-		curl -s "$1" > "$2";
+		curl -f -s "$1" > "$2"
 	elif [ $(which wget) ]; then
 		wget -nv -O "$2" "$1"
+	fi
+
+	# Exit if the last command failed.
+	if [ $? -ne 0 ]; then
+		echo "Downloading $1 failed"
+		exit 1
 	fi
 }
 

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -30,9 +30,9 @@ download() {
 	fi
 
 	if [ $(which curl) ]; then
-		curl -f -s "$1" > "$2" || echo "Download failed: $1" && exit 1;
+		curl -s "$1" > "$2";
 	elif [ $(which wget) ]; then
-		wget -nv -O "$2" "$1" || echo "Download failed: $1" && exit 1;
+		wget -nv -O "$2" "$1"
 	fi
 }
 

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -30,9 +30,9 @@ download() {
 	fi
 
 	if [ $(which curl) ]; then
-		curl -s "$1" > "$2";
+		curl -f -s "$1" > "$2" || echo "Download failed: $1" && exit 1;
 	elif [ $(which wget) ]; then
-		wget -nv -O "$2" "$1"
+		wget -nv -O "$2" "$1" || echo "Download failed: $1" && exit 1;
 	fi
 }
 


### PR DESCRIPTION
In light of today's silent error when raw.github.com failed and took down the CI with it, we should throw an error and exit 1 when the download fails.