### PR TITLE
Re-implement: Add VIP mu-plugins and object-cache installation

### DIFF
--- a/.github/workflows/test-script.yml
+++ b/.github/workflows/test-script.yml
@@ -11,28 +11,34 @@ name: Test Script
 jobs:
   test:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         wordpress: ["latest", "trunk", "6.0"]
+        install-core-tests: [0, 1]
     runs-on: ubuntu-latest
-    name: "Test Script ${{ matrix.wordpress }}"
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: "root"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    name: "Test Script ${{ matrix.wordpress }} - Core Suites: ${{ matrix.install-core-tests }}"
     env:
-      CACHEDIR: /tmp/test-cache
-      WP_CORE_DIR: /tmp/wordpress
+      WP_CORE_DIR: '/tmp/wordpress'
       WP_VERSION: ${{ matrix.wordpress }}
-      WP_DB_HOST: 127.0.0.1
-      WP_DB_USER: root
-      WP_DB_PASSWORD: 'password'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: "Run install-wp-tests.sh"
+      - name: "Run install-wp-tests.sh and check installation"
         shell: bash
         run: |
-          rm -rf $WP_CORE_DIR
-          bash install-wp-tests.sh wordpress_unit_tests "$WP_DB_USER" "$WP_DB_PASSWORD" "$WP_DB_HOST" $WP_VERSION true
-      - name: "Check Installation"
-        shell: bash
-        run: bash bin/test-script.sh
+          export INSTALL_WP_TEST_DEBUG=1
+          export WP_INSTALL_CORE_TEST_SUITE=${{ matrix.install-core-tests }}
+
+          # install-wp-tests.sh <db-name> <db-user> <db-pass> <db-host> <wp-version> <skip-database-creation> <install-mu-plugins> <install-memcached>
+          bash install-wp-tests.sh wordpress_unit_tests root root localhost "$WP_VERSION" false true true
+          bash bin/test-script.sh

--- a/.github/workflows/test-shellcheck.yml
+++ b/.github/workflows/test-shellcheck.yml
@@ -1,0 +1,19 @@
+name: Shellcheck
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Shellcheck
+      uses: ludeeus/action-shellcheck@master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Mantle Continuous Integration
 
 Contains the continuous integration scripts used inside the Mantle Framework and
-Mantle packages. Documentation can be found inside the [Mantle
-documentation](https://mantle.alley.co/).
+Mantle packages. Documentation can be found inside the
+[Mantle documentation](https://mantle.alley.com/).
+
+## Scripts
+
+- [`install-wp-tests.sh`](install-wp-tests.sh) - Script used internally by
+  Mantle for installing WordPress in a CI environment.

--- a/bin/test-script.sh
+++ b/bin/test-script.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+set -e
 
 # Test that the script ran correctly and properly installed WordPress.
+echo ""
+echo "Starting tests..."
 
 if [ ! -d "$WP_CORE_DIR" ]; then
   echo "$WP_CORE_DIR does not exist."
@@ -30,12 +33,12 @@ if ! grep -q "define( 'DB_USER', 'root' );" "$CONFIG_FILE"; then
   exit 1
 fi
 
-if ! grep -q "define( 'DB_PASSWORD', 'password' );" "$CONFIG_FILE"; then
+if ! grep -q "define( 'DB_PASSWORD', 'root' );" "$CONFIG_FILE"; then
   echo "DB_PASSWORD is not set correctly."
   exit 1
 fi
 
-if ! grep -q "define( 'DB_HOST', '127.0.0.1' );" "$CONFIG_FILE"; then
+if ! grep -q "define( 'DB_HOST', 'localhost' );" "$CONFIG_FILE"; then
   echo "DB_HOST is not set correctly."
   exit 1
 fi
@@ -43,6 +46,38 @@ fi
 if ! grep -q "defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );" "$CONFIG_FILE"; then
   echo "ABSPATH is not set correctly."
   exit 1
+fi
+
+if [ ! -d "$WP_CORE_DIR/wp-content/mu-plugins" ]; then
+  echo "$WP_CORE_DIR/wp-content/mu-plugins (https://github.com/Automattic/vip-go-mu-plugins-built.git) does not exist."
+  exit 1
+fi
+
+if [ ! -f "$WP_CORE_DIR/wp-content/object-cache.php" ]; then
+  echo "$WP_CORE_DIR/wp-content/object-cache.php does not exist."
+  exit 1
+fi
+
+# Check if the database was created.
+if ! mysql -u root -proot -h 127.0.0.1 -e "use wordpress_unit_tests"; then
+  echo "Database wordpress_unit_tests does not exist."
+  exit 1
+fi
+
+# If WP_INSTALL_CORE_TEST_SUITE is set to 1 then we should check if the core
+# test suite is installed.
+if [ "$WP_INSTALL_CORE_TEST_SUITE" == "1" ]; then
+  if [ ! -d "/tmp/wordpress-tests-lib/includes" ]; then
+    echo "/tmp/wordpress-tests-lib/includes does not exist."
+    exit 1
+  fi
+
+  if [ ! -f "/tmp/wordpress-tests-lib/includes/functions.php" ]; then
+    echo "/tmp/wordpress-tests-lib/includes/functions.php does not exist."
+    exit 1
+  fi
+else
+  echo "WP_INSTALL_CORE_TEST_SUITE is not set to 1."
 fi
 
 echo "WordPress installed successfully."

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -1,52 +1,161 @@
 #!/usr/bin/env bash
+set -e
 
-if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
-	exit 1
+# Install WordPress Tests for Development
+#
+# Primarily geared for development with Mantle framerwork/Mantle Testkit but also
+# supports installing the core WordPress test suite as well. Mirrors the
+# WordPress/wp-cli install-wp-tests.sh script with a few modifications:
+#
+# 1. By default it will not install the core test suite. This means that we will
+#    only install WordPress to `WP_CORE_DIR` but will not install the test suite
+#    to `WP_TESTS_DIR`. This can be configured by setting `WP_INSTALL_CORE_TEST_SUITE` to true.
+# 2. It will attempt to cache remote data requests for 4 hours. This can be
+#    configured by the `CACHEDIR` environment variable for the location of the cache
+#    directory. It can also be disabled by setting `CACHEDIR` to false.
+# 3. The script can optionally install Automattic's vip-mu-plugins-built as well as the
+#    object-cache.php file for Memcached support. This can be configured by the
+#    `INSTALL_VIP` environment variable (disabled by default) and the
+#    `INSTALL_MEMCACHED` environment variable (enabled by default).
+#
+# Usage:
+#
+# 	install-wp-tests.sh <db-name> <db-user> <db-pass> <db-host> <wp-version> <skip-database-creation> <install-mu-plugins> <install-memcached>
+#
+# Arguments (all are optional but must be in order and cannot be skipped):
+#
+# 	1. Database Name: defaults to "wordpress_unit_tests"
+# 	2. Database User: defaults to "root"
+# 	3. Database Password: defaults to ""
+# 	4. Database Host: defaults to "localhost"
+# 	5. WordPress Version: defaults to "latest"
+# 	6. Skip Database Creation: defaults to false
+# 	7. Install WordPress VIP's `Automattic/vip-go-mu-plugins-built` project to the `mu-plugins` directory: defaults to false
+# 	8. Install Memcached: defaults to false
+#
+# Environment Variables:
+#
+# 	CACHEDIR: The location of the cache directory.
+# 		Defaults to /tmp.
+# 	WP_CORE_DIR: The location of the WordPress core directory.
+# 		Defaults to /tmp/wordpress.
+# 	WP_TESTS_DIR: The location of the WordPress core test suite directory.
+# 		Defaults to /tmp/wordpress-tests-lib. Not used if INSTALL_CORE_TEST_SUITE is not true.
+# 	WP_MULTISITE: Whether or not to install WordPress as multisite.
+# 		Defaults to false.
+# 	WP_INSTALL_CORE_TEST_SUITE: Whether or not to install the WordPress core test suite.
+# 		Defaults to false.
+# 	WP_TESTS_TAG: The tag of the WordPress core test suite to install.
+# 		Defaults to "trunk".
+# 	INSTALL_WP_TEST_DEBUG: Whether or not to dump all variables for debugging.
+# 		Defaults to false.
+#
+# Example:
+#
+# 	install-wp-tests.sh wordpress_unit_tests root '' localhost latest false false false
+
+# Convenient functions for printing colored text
+function green {
+  # green text to stdout
+	echo "$@" | sed $'s,.*,\e[32m&\e[m,' | xargs -0 printf
+}
+
+function yellow {
+	# yellow text to stderr
+	echo "$@" | sed $'s,.*,\e[33m&\e[m,' | >&2 xargs -0 printf
+}
+
+function red {
+	# red text to stderr
+	echo "$@" | sed $'s,.*,\e[31m&\e[m,' | >&2 xargs -0 printf
+}
+
+# Handle true/false values
+function boolean() {
+  if [[ "$1" =~ ^(true|yes|on|1)$ ]]; then
+    echo "true"
+  elif [[ "$1" =~ ^(false|no|off|0)$ ]]; then
+    echo "false"
+  else
+    red "Error: Invalid boolean value for '$2': '$1'. Must be 'true' or 'false'."
+		exit 1
+  fi
+}
+
+# Arguments passed to the script directly with defaults.
+DB_NAME="${1:-wordpress_unit_tests}"
+DB_USER="${2:-root}"
+DB_PASS="${3:-}"
+DB_HOST="${4:-localhost}"
+WP_VERSION="${5:-latest}"
+SKIP_DB_CREATE=$(boolean "${6:-false}" "SKIP_DB_CREATE")
+INSTALL_VIP_MU_PLUGINS=$(boolean "${7:-false}" "INSTALL_VIP_MU_PLUGINS")
+INSTALL_OBJECT_CACHE=$(boolean "${8:-true}" "INSTALL_OBJECT_CACHE")
+
+# Environment variables with defaults.
+CACHEDIR=${CACHEDIR:-/tmp}
+CACHEDIR=$(echo "$CACHEDIR" | sed -e "s/\/$//") # Remove trailing slash if present.
+WP_CORE_DIR=${WP_CORE_DIR:-"${CACHEDIR}/wordpress"}
+WP_TESTS_DIR=${WP_TESTS_DIR:-/tmp/wordpress-tests-lib} # Only used with core test suite.
+WP_MULTISITE=${WP_MULTISITE:-0}
+WP_INSTALL_CORE_TEST_SUITE=$(boolean "${WP_INSTALL_CORE_TEST_SUITE:-false}" "WP_INSTALL_CORE_TEST_SUITE")
+INSTALL_WP_TEST_DEBUG=$(boolean "${INSTALL_WP_TEST_DEBUG:-false}" "INSTALL_WP_TEST_DEBUG")
+
+# Allow the script to dump all variables for debugging.
+if [ "$INSTALL_WP_TEST_DEBUG" = "true" ]; then
+	echo "WP_VERSION: ${WP_VERSION}"
+	echo "WP_CORE_DIR: ${WP_CORE_DIR}"
+	echo "CACHEDIR: ${CACHEDIR}"
+	echo "WP_TESTS_DIR: ${WP_TESTS_DIR}"
+	echo "WP_MULTISITE: ${WP_MULTISITE}"
+	echo "DB_NAME: ${DB_NAME}"
+	echo "DB_USER: ${DB_USER}"
+	echo "DB_PASS: ${DB_PASS}"
+	echo "DB_HOST: ${DB_HOST}"
+	echo "SKIP_DB_CREATE: ${SKIP_DB_CREATE}"
+	echo "INSTALL_VIP: ${INSTALL_VIP}"
+	echo "INSTALL_OBJECT_CACHE: ${INSTALL_OBJECT_CACHE}"
+	echo "WP_INSTALL_CORE_TEST_SUITE: ${WP_INSTALL_CORE_TEST_SUITE}"
 fi
 
-DB_NAME=$1
-DB_USER=$2
-DB_PASS=$3
-DB_HOST=${4-localhost}
-WP_VERSION=${5-latest}
-SKIP_DB_CREATE=${6-false}
-
-CACHEDIR=${CACHEDIR-/tmp}
-CACHEDIR=$(echo $CACHEDIR | sed -e "s/\/$//")
-
-WP_CORE_DIR=${WP_CORE_DIR-$CACHEDIR/wordpress/}
-
 # Create the cache directory if it doesn't exist.
-mkdir -p $CACHEDIR
+if [[ ! -d $CACHEDIR ]]; then
+	mkdir -p "$CACHEDIR" || red "Could not create directory $CACHEDIR" && exit 1
+fi
 
 download() {
 	# Check if the file has been downloaded in the last couple of hours.
 	# If it has been, use it instead of downloading it again.
 	if [[ -f $2 ]]; then
-		if test "$(find $2 -mmin -240)"; then
+		if test "$(find "$2" -mmin -240)"; then
+			if [ "$INSTALL_WP_TEST_DEBUG" = "true" ]; then
+				yellow "Using cached $2"
+			fi
+
 			return
 		fi
 	fi
 
-	if [ $(which curl) ]; then
+	if command -v curl >/dev/null 2>&1; then
 		curl -f -s "$1" > "$2"
-	elif [ $(which wget) ]; then
+	elif command -v wget >/dev/null 2>&1; then
 		wget -nv -O "$2" "$1"
+	else
+		red "Could not find curl or wget"
+		exit 1
 	fi
 
 	# Exit if the last command failed.
+	# shellcheck disable=SC2181
 	if [ $? -ne 0 ]; then
 		echo "Downloading $1 failed"
 		exit 1
 	fi
 }
 
-if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
-	WP_BRANCH=${WP_VERSION%\-*}
-	WP_TESTS_TAG="branches/$WP_BRANCH"
-
-elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+# Determine the WordPress core test tag to install and the latest version of
+# WordPress that can be installed.
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
 	WP_TESTS_TAG="branches/$WP_VERSION"
 elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
 	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
@@ -60,8 +169,9 @@ elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
 	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
-	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+
 	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+
 	if [[ -z "$LATEST_VERSION" ]]; then
 		echo "Latest WordPress version could not be found"
 		exit 1
@@ -69,50 +179,51 @@ else
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
 
-set -e
-
 install_wp() {
-	if [ -d $WP_CORE_DIR ]; then
-		if [ -f $WP_CORE_DIR/wp-load.php ]; then
+	if [ -d "$WP_CORE_DIR" ]; then
+		if [ -f "$WP_CORE_DIR/wp-load.php" ]; then
 			echo "WordPress already installed at [$WP_CORE_DIR]"
 			return
 		fi
 	fi
 
-	mkdir -p $WP_CORE_DIR
+	green "Installing WordPress at [$WP_CORE_DIR]"
+
+	mkdir -p "$WP_CORE_DIR"
 
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-		mkdir -p $CACHEDIR/wordpress-nightly
-		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $CACHEDIR/wordpress-nightly/wordpress-nightly.zip
-		unzip -q $CACHEDIR/wordpress-nightly/wordpress-nightly.zip -d $CACHEDIR/wordpress-nightly/
-		mv $CACHEDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
+		mkdir -p "$CACHEDIR/wordpress-nightly"
+		download "https://wordpress.org/nightly-builds/wordpress-latest.zip"  "$CACHEDIR/wordpress-nightly/wordpress-nightly.zip"
+		unzip -q "$CACHEDIR/wordpress-nightly/wordpress-nightly.zip" -d "$CACHEDIR/wordpress-nightly/"
+		mv "$CACHEDIR/wordpress-nightly/wordpress/"* "$WP_CORE_DIR"
 	else
-		if [ $WP_VERSION == 'latest' ]; then
-			local ARCHIVE_NAME='latest'
+		if [ "$WP_VERSION" == 'latest' ]; then
+			ARCHIVE_NAME='latest'
 		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
 			# https serves multiple offers, whereas http serves single.
-			download https://api.wordpress.org/core/version-check/1.7/ $CACHEDIR/wp-latest.json
+			download "https://api.wordpress.org/core/version-check/1.7/" "$CACHEDIR/wp-latest.json"
 			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
 				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
 				LATEST_VERSION=${WP_VERSION%??}
 			else
 				# otherwise, scan the releases and get the most up to date minor version of the major release
-				local VERSION_ESCAPED=$(echo $WP_VERSION | sed 's/\./\\\\./g')
-				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $CACHEDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+				# shellcheck disable=SC2001
+				VERSION_ESCAPED=$(echo "$WP_VERSION" | sed 's/\./\\\\./g')
+				LATEST_VERSION=$(grep -o '"version":"'"$VERSION_ESCAPED"'[^"]*' "$CACHEDIR/wp-latest.json" | sed 's/"version":"//' | head -1)
 			fi
 			if [[ -z "$LATEST_VERSION" ]]; then
-				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+				ARCHIVE_NAME="wordpress-$WP_VERSION"
 			else
-				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+				ARCHIVE_NAME="wordpress-$LATEST_VERSION"
 			fi
 		else
-			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi
-		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $CACHEDIR/wordpress.tar.gz
-		tar --strip-components=1 -zxmf $CACHEDIR/wordpress.tar.gz -C $WP_CORE_DIR
+		download "https://wordpress.org/${ARCHIVE_NAME}.tar.gz" "$CACHEDIR/wordpress.tar.gz"
+		tar --strip-components=1 -zxmf "$CACHEDIR/wordpress.tar.gz" -C "$WP_CORE_DIR"
 	fi
 
-	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/wp-content/db.php"
 }
 
 install_config() {
@@ -123,10 +234,15 @@ install_config() {
 		local ioption='-i'
 	fi
 
+	green "Installing wp-tests-config.php"
+
 	if [ ! -f wp-tests-config.php ]; then
-		download https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/wp-tests-config-sample.php "$WP_CORE_DIR"/wp-tests-config.php
+		download https://raw.githubusercontent.com/alleyinteractive/mantle-ci/HEAD/wp-tests-config-sample.php "$WP_CORE_DIR/wp-tests-config.php"
+
 		# remove all forward slashes in the end
-		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		# shellcheck disable=SC2001
+		WP_CORE_DIR=$(echo "$WP_CORE_DIR" | sed "s:/\+$::")
+
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_CORE_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_CORE_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_CORE_DIR"/wp-tests-config.php
@@ -135,37 +251,133 @@ install_config() {
 	fi
 }
 
-install_db() {
-
-	if [ "${SKIP_DB_CREATE}" = "true" ]; then
+install_test_suite() {
+	if [ "$WP_INSTALL_CORE_TEST_SUITE" != "true" ]; then
+		yellow "Skipping installing core test suite"
 		return
 	fi
 
+	green "Installing core test suite to $WP_TESTS_DIR"
+
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d "$WP_TESTS_DIR" ]; then
+		# set up testing suite
+		mkdir -p "$WP_TESTS_DIR"
+		svn co --quiet "https://develop.svn.wordpress.org/$WP_TESTS_TAG/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
+		svn co --quiet "https://develop.svn.wordpress.org/$WP_TESTS_TAG/tests/phpunit/data/" "$WP_TESTS_DIR/data"
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download "https://develop.svn.wordpress.org/$WP_TESTS_TAG/wp-tests-config-sample.php" "$WP_TESTS_DIR"/wp-tests-config.php
+
+		# Remove the trailing forward slash
+		# shellcheck disable=SC2001
+		WP_CORE_DIR=$(echo "$WP_CORE_DIR" | sed "s:/\+$::")
+
+		sed "$ioption" "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed "$ioption" "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed "$ioption" "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed "$ioption" "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed "$ioption" "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+}
+
+install_db() {
+	if [ "${SKIP_DB_CREATE}" = "true" ]; then
+		yellow "Skipping database creation"
+		return
+	fi
+
+	green "Creating database $DB_NAME"
+
 	# parse DB_HOST for port or socket references
-	local PARTS=(${DB_HOST//\:/ })
-	local DB_HOSTNAME=${PARTS[0]};
-	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local PARTS=("${DB_HOST//:/ }")
+	local DB_HOSTNAME=${PARTS[0]}
+	local DB_SOCK_OR_PORT=${PARTS[1]}
 	local EXTRA=""
 
-	if ! [ -z $DB_HOSTNAME ] ; then
-		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+	if [ -n "$DB_HOSTNAME" ]; then
+		if echo "$DB_SOCK_OR_PORT" | grep -q -e '^[0-9]\{1,\}$'; then
 			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
-		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+		elif [ -n "$DB_SOCK_OR_PORT" ]; then
 			EXTRA=" --socket=$DB_SOCK_OR_PORT"
-		elif ! [ -z $DB_HOSTNAME ] ; then
+		elif [ -n "$DB_HOSTNAME" ]; then
 			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
 		fi
 	fi
 
-	# Drop the database before creating it.
-	set +e
-	mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
-	set -e
+	# Drop the database if it exists.
+	# shellcheck disable=SC2086
+	mysqladmin drop "$DB_NAME" -f --user="$DB_USER" --password="$DB_PASS"$EXTRA || true
 
-	# create database
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	# Create the new databaase.
+	# shellcheck disable=SC2086
+	mysqladmin create "$DB_NAME" --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_vip_mu_plugins() {
+	if [ "$INSTALL_VIP_MU_PLUGINS" != "true" ]; then
+		yellow "Skipping installing mu-plugins"
+		return
+	fi
+
+	green "Cloning VIP Go mu-plugins"
+
+	cd "${WP_CORE_DIR}/wp-content/"
+
+	# Checkout VIP Go mu-plugins to mu-plugins
+	if [ ! -d "mu-plugins" ]; then
+		git clone \
+			--quiet \
+			--recursive \
+			--depth=1 \
+			https://github.com/Automattic/vip-go-mu-plugins-built.git mu-plugins
+	else
+		# Check if this is a Git clone of the built mu-plugins. Bail out if it is not.
+		if [ ! -d "mu-plugins/.git" ]; then
+			red "mu-plugins already exists and is not a Git clone, aborting"
+			return
+		fi
+
+		yellow "VIP Go mu-plugins already exists, attempting to update"
+		cd mu-plugins
+		git pull
+		cd ..
+	fi
+}
+
+install_object_cache() {
+	if [ "$INSTALL_OBJECT_CACHE" != "true" ]; then
+		yellow "Skipping installing object-cache.php"
+		return
+	fi
+
+	# Check if the file exists.
+	if [ -f "${WP_CORE_DIR}/wp-content/object-cache.php" ]; then
+		yellow "object-cache.php already exists, skipping"
+		return
+	fi
+
+	green "Installing object-cache.php"
+
+	# Download the object cache drop-in.
+	# TODO: use the mu-plugins object-cache.php instead if this is a VIP project
+	# (requires setting the VIP_GO_APP_ENVIRONMENT constant).
+	download "https://raw.githubusercontent.com/Automattic/wp-memcached/HEAD/object-cache.php" "${WP_CORE_DIR}/wp-content/object-cache.php"
 }
 
 install_wp
+install_test_suite
 install_config
 install_db
+install_vip_mu_plugins
+install_object_cache
+
+green "Ready to test ${WP_CORE_DIR}/wp-content/ 🚀"

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -172,9 +172,9 @@ elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
-	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	download http://api.wordpress.org/core/version-check/1.7/ "$CACHEDIR/wp-latest.json"
 
-	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' "$CACHEDIR/wp-latest.json" | sed 's/"version":"//')
 
 	if [[ -z "$LATEST_VERSION" ]]; then
 		echo "Latest WordPress version could not be found"

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -103,6 +103,10 @@ INSTALL_WP_TEST_DEBUG=$(boolean "${INSTALL_WP_TEST_DEBUG:-false}" "INSTALL_WP_TE
 
 # Allow the script to dump all variables for debugging.
 if [ "$INSTALL_WP_TEST_DEBUG" = "true" ]; then
+	# Display all commands being run for easy debugging.
+	set -x
+
+	green "Dumping all variables for debugging:"
 	echo "WP_VERSION: ${WP_VERSION}"
 	echo "WP_CORE_DIR: ${WP_CORE_DIR}"
 	echo "CACHEDIR: ${CACHEDIR}"

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -123,9 +123,7 @@ if [ "$INSTALL_WP_TEST_DEBUG" = "true" ]; then
 fi
 
 # Create the cache directory if it doesn't exist.
-if [[ ! -d $CACHEDIR ]]; then
-	mkdir -p "$CACHEDIR" || (red "Could not create cache directory at $CACHEDIR" && exit 1)
-fi
+mkdir -p "$CACHEDIR"
 
 download() {
 	# Check if the file has been downloaded in the last couple of hours.

--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -124,7 +124,7 @@ fi
 
 # Create the cache directory if it doesn't exist.
 if [[ ! -d $CACHEDIR ]]; then
-	mkdir -p "$CACHEDIR" || red "Could not create directory $CACHEDIR" && exit 1
+	mkdir -p "$CACHEDIR" || (red "Could not create cache directory at $CACHEDIR" && exit 1)
 fi
 
 download() {


### PR DESCRIPTION
Reverts alleyinteractive/mantle-ci#9 and reimplements #8

## Changes

- Option to install https://github.com/Automattic/vip-go-mu-plugins-built.git from the script.
- Option to install `object-cache.php` from the script.
- Option to install core's testing suite (https://develop.svn.wordpress.org) to `WP_TESTS_DIR`. This is disabled by default.
- Adds documentation for all the arguments and available environmental variables that can be set by the user.

The next step here will be to add support to Mantle Testkit to control these options and allow projects to install `mu-plugins` and `object-cache.php` all within their `tests/bootstrap.php`.