### PR TITLE
Install 000-pre-vip-config/requires.php and vip-config/vip-config.php to wp-tests-config.php if installing VIPs mu-plugins

### DIFF
--- a/bin/test-script.sh
+++ b/bin/test-script.sh
@@ -58,6 +58,16 @@ if [ ! -f "$WP_CORE_DIR/wp-content/object-cache.php" ]; then
   exit 1
 fi
 
+if ! grep -q "require_once ABSPATH . 'wp-content/mu-plugins/000-pre-vip-config/requires.php';" "$CONFIG_FILE"; then
+  echo "mu-plugins/000-pre-vip-config/requires.php is not loaded in wp-tests-config.php."
+  exit 1
+fi
+
+if ! grep -q "require_once ABSPATH . 'wp-content/vip-config/vip-config.php';" "$CONFIG_FILE"; then
+  echo "vip-config/vip-config.php is not loaded in wp-tests-config.php."
+  exit 1
+fi
+
 # Check if the database was created.
 if ! mysql -u root -proot -h 127.0.0.1 -e "use wordpress_unit_tests"; then
   echo "Database wordpress_unit_tests does not exist."


### PR DESCRIPTION
To ensure better compatibility with VIP's mu-plugins, we should follow their platform requirements and load the following files early in our `wp-tests-config.php`:

- `mu-plugins/000-pre-vip-config/requires.php`
- `vip-config/vip-config.php`

These files are only loaded if they exist. The `vip-config.php` part can be defined by setting `INSTALL_VIP_CONFIG` to `false`. By default, when the VIP `mu-plugins` are installed we'll also install the `vip-config/vip-config.php` file.

These files are already loaded locally and not loading them in a testing environment is causing the code in `vip-config/vip-config.php` not to be run. 

See https://docs.wpvip.com/how-tos/third-party-local-development/#h-step-4-update-wp-config-php

Props to @jakewrfoster for pointing this out to me.