### PR TITLE
Fix shortened reference to WP_INSTALL_CORE_TEST_SUITE

### DIFF
--- a/install-wp-tests.sh
+++ b/install-wp-tests.sh
@@ -39,7 +39,7 @@ set -e
 # 	WP_CORE_DIR: The location of the WordPress core directory.
 # 		Defaults to /tmp/wordpress.
 # 	WP_TESTS_DIR: The location of the WordPress core test suite directory.
-# 		Defaults to /tmp/wordpress-tests-lib. Not used if INSTALL_CORE_TEST_SUITE is not true.
+# 		Defaults to /tmp/wordpress-tests-lib. Not used if WP_INSTALL_CORE_TEST_SUITE is not true.
 # 	WP_MULTISITE: Whether or not to install WordPress as multisite.
 # 		Defaults to false.
 # 	WP_INSTALL_CORE_TEST_SUITE: Whether or not to install the WordPress core test suite.


### PR DESCRIPTION
If applied, this PR will fix a commented reference to the `WP_INSTALL_CORE_TEST_SUITE` variable.